### PR TITLE
ci: forbid uses @v* (require pinned SHA) (Issue #13)

### DIFF
--- a/.github/workflows/ci-forbid-uses-tag.yml
+++ b/.github/workflows/ci-forbid-uses-tag.yml
@@ -1,0 +1,31 @@
+name: CI - Forbid uses @v* (require pinned SHA)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout (pinned)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Fail when any uses references @v*
+        shell: bash
+        run: |
+          set -euo pipefail
+          hits=$(grep -RInE "^\s*uses: .*@v[0-9]" .github/workflows || true)
+          if [ -n "$hits" ]; then
+            echo "Found forbidden uses tags:" >&2
+            echo "$hits" >&2
+            exit 1
+          fi
+          echo "No forbidden uses tags detected."
+
+


### PR DESCRIPTION
目的: .github/workflows 内の Action 参照がタグ指定（@v*）になっている場合にCIでFail

- 追加: .github/workflows/ci-forbid-uses-tag.yml
- 検査: `grep -RInE '^\s*uses: .*@v[0-9]' .github/workflows` で検出したらFail
- 補足: actionlint 等への拡張は後続PRで検討
- ルール準拠: actions-security.mdc
