### PR TITLE
ci: block prohibited paths in PR (.specstory/**, .next/**, venv/**, logs/**, etc.) (Issue #14)

### DIFF
--- a/.github/workflows/block-prohibited-paths.yml
+++ b/.github/workflows/block-prohibited-paths.yml
@@ -1,0 +1,32 @@
+name: CI - Block prohibited paths in PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  block:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout (pinned)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          persist-credentials: false
+
+      - name: Detect prohibited paths in PR diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROHIBITED_REGEX='^(\.specstory/|\.next/|venv/|logs/|tmp-public/|__pycache__/|projects/|\.vscode/|\.DS_Store)'
+          # Collect changed files in PR
+          files=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH" | xargs -I{} curl -sSL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/${{ github.repository }}/pulls/{}/files?per_page=100" | jq -r '.[].filename')
+          echo "$files" | sed '/^$/d' > changed_files.txt || true
+          if grep -E "$PROHIBITED_REGEX" changed_files.txt > hits.txt; then
+            echo "Found prohibited paths in PR diff:" >&2
+            cat hits.txt >&2
+            exit 1
+          fi
+          echo "No prohibited paths detected."


### PR DESCRIPTION
目的: 公開禁止パス（.specstory/**, .next/**, venv/**, logs/** ほか）をPR差分に含めない

- 追加: .github/workflows/block-prohibited-paths.yml
- 検査: PR差分のファイル一覧から正規表現で検知→Fail
- セキュリティ: actions/checkout はSHA固定、最小権限
- 今後: paths-filter等での厳密化や許可例外の明示を拡張予定

参考: `.cursor/rules/publishing-isolation.mdc`, `.cursor/rules/actions-security.mdc`, `.cursor/rules/docs-sync-policy.mdc`
